### PR TITLE
Enables no-js class.

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -13,9 +13,8 @@ import cookies from './components/cookies';
 
 touchable();
 
-if (isExplorer()) {
-  document.documentElement.classList.add('browser-ie');
-}
+if (isExplorer()) document.documentElement.classList.add('browser-ie');
+document.documentElement.classList.remove('no-js');
 
 events.onDocumentReady(() => {
   cookies();

--- a/templates/layouts/base.html.twig
+++ b/templates/layouts/base.html.twig
@@ -1,7 +1,7 @@
 {% set locale = app.request.locale %}
 {% set model = page.content %}
 <!doctype html>
-<html lang="{{ locale }}" class="non-touch">
+<html lang="{{ locale }}" class="no-js non-touch">
     <head>
         <meta charset="utf-8">
         {% include 'modules/tagmanager.html.twig' %}


### PR DESCRIPTION
Adds `no-js` class to html tag. Removes the class once the js is called.

Unifies with Drupal Archetype.