### PR TITLE
Remove HSTS localhost

### DIFF
--- a/.docker/nginx-dev/nginx.conf
+++ b/.docker/nginx-dev/nginx.conf
@@ -115,7 +115,6 @@ http {
         server_tokens off;
         http2_push_preload on;
 
-        add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload" always;
         add_header X-Content-Type-Options nosniff always;
         add_header X-Frame-Options SAMEORIGIN always;
         add_header X-XSS-Protection "1; mode=block" always;

--- a/.docker/nginx-prod/nginx.conf
+++ b/.docker/nginx-prod/nginx.conf
@@ -50,6 +50,11 @@ http {
         resolver_timeout 5s;
         resolver 1.1.1.1 1.0.0.1 valid=300s;
 
+        add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload" always;
+        add_header X-Content-Type-Options nosniff always;
+        add_header X-Frame-Options SAMEORIGIN always;
+        add_header X-XSS-Protection "1; mode=block" always;
+
         etag off;
     }
 }


### PR DESCRIPTION
Removing this header on localhost allows to avoid an eternal redirect to https on all localhost hosts.
This is useful when not ALL local hosts are running under https. (Ex: a nextjs app).

Also not really needed on localhost.