### PR TITLE
reuseNode as much as possible to avoid deadlocks

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,6 +18,7 @@ pipeline {
         stage('Continuous Integration - PHP') {
             agent {
                 docker { image 'runroom/php8.1-cli' }
+                reuseNode true
             }
 
             steps {
@@ -57,6 +58,7 @@ pipeline {
         stage('Continuous Integration - Node') {
             agent {
                 docker { image 'runroom/node17' }
+                reuseNode true
             }
 
             steps {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,8 +17,10 @@ pipeline {
     stages {
         stage('Continuous Integration - PHP') {
             agent {
-                docker { image 'runroom/php8.1-cli' }
-                reuseNode true
+                docker { 
+                    image 'runroom/php8.1-cli'
+                    reuseNode true
+                }
             }
 
             steps {
@@ -57,8 +59,10 @@ pipeline {
 
         stage('Continuous Integration - Node') {
             agent {
-                docker { image 'runroom/node17' }
-                reuseNode true
+                docker { 
+                    image 'runroom/node17'
+                    reuseNode true
+                }
             }
 
             steps {


### PR DESCRIPTION
If this option is not set, jenkins will try to find a new Node for each agent change. That will end up causing deadlocks if a lot of jobs are executed.

https://issues.jenkins.io/browse/JENKINS-60701