### PR TITLE
Fix xdebug for console and tests, fix composer php version

### DIFF
--- a/.docker/app-dev/extra.ini
+++ b/.docker/app-dev/extra.ini
@@ -15,6 +15,7 @@ realpath_cache_ttl = 7200
 error_log = /proc/self/fd/2
 
 xdebug.mode = debug
-xdebug.start_with_request = trigger
-xdebug.discover_client_host = 1
+xdebug.start_with_request = yes
+xdebug.discover_client_host = 0
 xdebug.client_host = host.docker.internal
+xdebug.log_level = 0

--- a/composer.json
+++ b/composer.json
@@ -115,10 +115,10 @@
         }
     },
     "scripts": {
-        "lint-twig": "bin/console lint:twig templates",
-        "lint-yaml": "bin/console lint:yaml config src translations --parse-tags",
-        "php-cs-fixer": "php-cs-fixer fix --ansi --verbose",
-        "phpstan": "phpstan analyse --no-progress",
-        "psalm": "psalm --stats"
+        "lint-twig": "@php bin/console lint:twig templates",
+        "lint-yaml": "@php bin/console lint:yaml config src translations --parse-tags",
+        "php-cs-fixer": "@php php-cs-fixer fix --ansi --verbose",
+        "phpstan": "@php phpstan analyse --no-progress",
+        "psalm": "@php psalm --stats"
     }
 }

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -9,6 +9,8 @@ services:
         build:
             context: .
             target: fpm-dev
+        environment:
+            PHP_IDE_CONFIG: serverName=localhost
         volumes:
             - ./:/usr/app/:cached
             - .docker/app-dev/extra.ini:/usr/local/etc/php/conf.d/extra.ini


### PR DESCRIPTION
Xdebug is now always enabled to enable debugging console commands or test execution.
It does not affect in performance or atleast it is not really noticeable.

PHP_IDE_CONFIG env var allows to debug commands or tests execution using PHPStorm / other IDEs.

On the other hand, composer script now run in the same php version that the command running composer, to avoid possible problems with version missmatch on systems with multiple php versions installed at the same time.