### PR TITLE
Fix GID already exists error in macOS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ARG UID=1000
 ARG GID=1000
 
 RUN usermod -u $UID www-data
-RUN groupmod -g $GID www-data
+RUN groupmod -g $GID -o www-data
 
 COPY --from=mlocati/php-extension-installer:latest /usr/bin/install-php-extensions /usr/bin/
 
@@ -112,7 +112,7 @@ ARG UID=1000
 ARG GID=1000
 
 RUN usermod -u $UID nginx
-RUN groupmod -g $GID nginx
+RUN groupmod -g $GID -o nginx
 
 # NGINX-PROD
 # FROM nginx-base as nginx-prod

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ARG UID=1000
 ARG GID=1000
 
 RUN usermod -u $UID www-data
-RUN groupmod -g $GID -o www-data
+RUN groupmod -o -g $GID www-data
 
 COPY --from=mlocati/php-extension-installer:latest /usr/bin/install-php-extensions /usr/bin/
 
@@ -112,7 +112,7 @@ ARG UID=1000
 ARG GID=1000
 
 RUN usermod -u $UID nginx
-RUN groupmod -g $GID -o nginx
+RUN groupmod -o -g $GID nginx
 
 # NGINX-PROD
 # FROM nginx-base as nginx-prod

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ARG UID=1000
 ARG GID=1000
 
 RUN usermod -u $UID www-data
-RUN groupmod -o -g $GID www-data
+RUN groupmod --non-unique -g $GID www-data
 
 COPY --from=mlocati/php-extension-installer:latest /usr/bin/install-php-extensions /usr/bin/
 
@@ -112,7 +112,7 @@ ARG UID=1000
 ARG GID=1000
 
 RUN usermod -u $UID nginx
-RUN groupmod -o -g $GID nginx
+RUN groupmod --non-unique -g $GID nginx
 
 # NGINX-PROD
 # FROM nginx-base as nginx-prod

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,8 @@ FROM php:8.1-fpm as fpm-base
 ARG UID=1000
 ARG GID=1000
 
-RUN usermod -u $UID www-data
-RUN groupmod --non-unique -g $GID www-data
+RUN usermod --uid $UID www-data
+RUN groupmod --non-unique --gid $GID www-data
 
 COPY --from=mlocati/php-extension-installer:latest /usr/bin/install-php-extensions /usr/bin/
 
@@ -111,8 +111,8 @@ FROM nginx:1.23 as nginx-base
 ARG UID=1000
 ARG GID=1000
 
-RUN usermod -u $UID nginx
-RUN groupmod --non-unique -g $GID nginx
+RUN usermod --uid $UID nginx
+RUN groupmod --non-unique --gid $GID nginx
 
 # NGINX-PROD
 # FROM nginx-base as nginx-prod


### PR DESCRIPTION
Add the `--non-unique` flag to `groupmod` commands to avoid already exists error in m1 chip macOS computers.