### PR TITLE
Ignore more folders for the docker build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,14 @@
+.git
+.docker/*
+!.docker/app
+!.docker/nginx
+!.docker/traefik
+.github
 coverage
+doc
 node_modules
-var
-vendor
 public/build/*
 public/bundles
 public/uploads/*
+var
+vendor


### PR DESCRIPTION
The .git folder increased the prod build by a lot if you had a complete checkout of the repository.