### PR TITLE
Fix MacOS builds

### DIFF
--- a/.docker/make/01_setup.mk
+++ b/.docker/make/01_setup.mk
@@ -3,12 +3,14 @@ CERTS_DIR = .docker/traefik/certs
 BUILD_DIR = public/build
 
 setup: ## Create the directories and files needed for local development.
-	mkdir --parents $(NODE_MODULES_DIR)
+	# MacOS does not support --parents for the mkdir command
+	mkdir -p $(NODE_MODULES_DIR)
 	[ -f $(BUILD_DIR)/manifest.json ] || echo '{}' > $(BUILD_DIR)/manifest.json
 .PHONY: setup
 
 certs: ## Create a self-signed certificate for local development.
 	mkcert -install
-	mkdir --parents $(CERTS_DIR)
+	# MacOS does not support --parents for the mkdir command
+	mkdir -p $(CERTS_DIR)
 	mkcert -cert-file $(CERTS_DIR)/cert.crt -key-file $(CERTS_DIR)/cert.key localhost
 .PHONY: certs


### PR DESCRIPTION
MacOS mkdir only supports -p short option.