### PR TITLE
Improve entrypoint for reset database operation

### DIFF
--- a/.docker/app/base/entrypoint.sh
+++ b/.docker/app/base/entrypoint.sh
@@ -5,7 +5,8 @@
 if [ "${RESET_DATABASE:-}" = true ]; then
     echo 'Resetting database...'
 
-    console doctrine:schema:drop --full-database --no-interaction --force
+    console doctrine:database:drop --no-interaction --force
+    console doctrine:database:create --no-interaction
     console doctrine:migrations:migrate --no-interaction --allow-no-migration
     APP_ENV=staging console doctrine:fixtures:load --no-interaction --append
 


### PR DESCRIPTION
## Description

Schema drop and migrations:migrate is not working correctly. Seems like it is not dropping the migrations table, so it does not apply all migrations.

For now lets drop and create database. If when we can update to a more recent version of dbal and orm this is fixed we might revert this PR.

---

## Checklist
Ensure your pull request meets the following requirements:

- [x] Tests have been added or updated.
- [x] Documentation has been updated (if applicable).
- [x] I have applied neccessary labels to this PR.
- [x] I have tested this change locally and on staging.
- [x] At a functional level, it has been validated with the team/PO.
