### PR TITLE
Remove crashing mailer Docker config

### DIFF
--- a/.docker/docker-compose.yaml
+++ b/.docker/docker-compose.yaml
@@ -20,9 +20,6 @@ services:
             - 8432:5432
     mailer:
         image: axllent/mailpit
-        healthcheck:
-            start_interval: 15s
-            interval: 5s
         labels:
             traefik.enable: true
             traefik.http.services.mailer.loadbalancer.server.port: 8025


### PR DESCRIPTION
This pull request includes a small change to the `.docker/docker-compose.yaml` file. The change removes the `healthcheck` configuration from the `mailer` service.