### PR TITLE
Remove mkcert install command from setup

### DIFF
--- a/.docker/make/01_setup.mk
+++ b/.docker/make/01_setup.mk
@@ -12,7 +12,6 @@ certs: ## Create a self-signed certificate for local development.
 ifndef MKCERT
 	$(info No mkcert was found in PATH, install it from here: https://github.com/FiloSottile/mkcert)
 else
-	mkcert -install
 	mkcert -cert-file $(CERTS_DIR)/cert.crt -key-file $(CERTS_DIR)/cert.key localhost
 endif
 .PHONY: certs


### PR DESCRIPTION
This pull request makes a minor adjustment to the certificate generation process for local development. The change removes the redundant `mkcert -install` command, streamlining the setup step.
